### PR TITLE
Add manifest for Samsung Galaxy Tab 2

### DIFF
--- a/espresso3g.xml
+++ b/espresso3g.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="device/samsung/espresso3g"   name="CyanogenMod/android_device_samsung_espresso3g"       revision="cm-13.0" />
+  <project path="device/samsung/espressowifi" name="CyanogenMod/android_device_samsung_espressowifi"     revision="cm-13.0" />
+  <project path="kernel/samsung/espresso10"   name="CyanogenMod/android_kernel_samsung_espresso10"       revision="cm-13.0" />
+  <project path="hardware/samsung"            name="CyanogenMod/android_hardware_samsung"                revision="cm-13.0" />
+  <project path="hardware/ti/omap4"           name="CyanogenMod/android_hardware_ti_omap4"               revision="cm-13.0" />
+  <project path="vendor/samsung"              name="TheMuppets/proprietary_vendor_samsung"               revision="cm-13.0" />
+
+  <project path="rpm"                                 name="MightyM17/droid-hal-espresso3g"         revision="master" />
+  <project path="hybris/droid-configs"                name="MightyM17/droid-config-espresso3g"      revision="master" />
+  <project path="hybris/droid-hal-version-espresso3g" name="MightyM17/droid-hal-version-espresso3g" revision="master" />
+</manifest>


### PR DESCRIPTION
This uses cm13 sources and has ran with sfos 3.4.0.24, but to get display one needs to manually start surfaceflinger. Is there a fix for that?